### PR TITLE
docs: add note that this plugin is not yet working

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # PostCSS Var Fallback
 
+> NOTE: THIS IS NOT YET WORKING
+
+In case you've run across this and want to use it, it won't work yet.
+
 [![NPM Version](https://img.shields.io/npm/v/@silvermine/postcss-css-var-fallback.svg)](https://www.npmjs.com/package/@silvermine/postcss-css-var-fallback)
 [![License](https://img.shields.io/github/license/silvermine/postcss-css-var-fallback.svg)](./LICENSE)
 [![Build Status](https://travis-ci.com/silvermine/postcss-css-var-fallback.svg?branch=main)](https://travis-ci.com/silvermine/postcss-css-var-fallback)


### PR DESCRIPTION
I doubt it will be an issue, but since this is a public repo I wanted to leave a note that there's no actual plugin code in the main branch. The code is still in someone's fork.