### PR TITLE
chore: upgrade standardization, remove markdownlint-cli dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "postcss-var-fallback",
+  "name": "@silvermine/postcss-css-var-fallback",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -1074,9 +1074,9 @@
       }
     },
     "@silvermine/standardization": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@silvermine/standardization/-/standardization-1.1.0.tgz",
-      "integrity": "sha512-U8yINmiQiDRAQwQYOV5eoZ+RQHOMEP0QO3vWTCCf+hBrP3KY7TNfMrVuWkH87t6CB77s+uHLRER65UwLA69liw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@silvermine/standardization/-/standardization-1.2.0.tgz",
+      "integrity": "sha512-qrIzsDlgt0P3I+UOJnLBoYjFdJABqNF8P0LoQ4SDoVCor2oyD+wVZaEmPpdCazdyXNuzmsKRZgXw24YZ/csj8Q==",
       "dev": true,
       "requires": {
         "@commitlint/cli": "12.1.1",
@@ -1085,6 +1085,7 @@
         "grunt-markdownlint": "2.9.0",
         "grunt-stylelint": "0.16.0",
         "markdownlint": "0.19.0",
+        "markdownlint-cli": "0.28.1",
         "stylelint": "13.13.1",
         "stylelint-config-standard": "22.0.0",
         "stylelint-scss": "3.19.0"
@@ -2308,9 +2309,9 @@
       "dev": true
     },
     "conventional-changelog-angular": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.12.tgz",
-      "integrity": "sha512-5GLsbnkR/7A89RyHLvvoExbiGbd9xKdKqDTrArnPbOqBqG/2wIosu0fHwpeIRI8Tl94MhVNBXcLJZl92ZQ5USw==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
+      "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0",
@@ -2318,9 +2319,9 @@
       }
     },
     "conventional-commits-parser": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.1.tgz",
-      "integrity": "sha512-OG9kQtmMZBJD/32NEw5IhN5+HnBqVjy03eC+I71I0oQRFA5rOgA4OtPOYG7mz1GkCfCNxn3gKIX8EiHJYuf1cA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.2.tgz",
+      "integrity": "sha512-Jr9KAKgqAkwXMRHjxDwO/zOCDKod1XdAESHAGuJX38iZ7ZzVti/tvVoysO0suMsdAObp9NQ2rHSsSbnAqZ5f5g==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.0.4",
@@ -2328,8 +2329,7 @@
         "lodash": "^4.17.15",
         "meow": "^8.0.0",
         "split2": "^3.0.0",
-        "through2": "^4.0.0",
-        "trim-off-newlines": "^1.0.0"
+        "through2": "^4.0.0"
       }
     },
     "convert-source-map": {
@@ -7785,12 +7785,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
-      "dev": true
-    },
-    "trim-off-newlines": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
       "dev": true
     },
     "trough": {

--- a/package.json
+++ b/package.json
@@ -23,12 +23,11 @@
   },
   "devDependencies": {
     "@silvermine/eslint-config": "3.0.1",
-    "@silvermine/standardization": "1.1.0",
+    "@silvermine/standardization": "1.2.0",
     "coveralls": "3.1.1",
     "eslint": "6.8.0",
     "eslint-plugin-jest": "24.2.1",
-    "jest": "26.6.3",
-    "markdownlint-cli": "0.28.1"
+    "jest": "26.6.3"
   },
   "jest": {
     "testEnvironment": "node",


### PR DESCRIPTION
Markdownlint-cli is included with the latest version of standardization,
so it's removed in this commit as a direct dependency.