### PR TITLE
Refactor for better performance, fix bug for declarations with multiple CSS var statements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
    - "node" # Latest node version
    - "lts/*" # Latest LTS version
    - "12"
-   - "10"
 
 cache: false
 

--- a/README.md
+++ b/README.md
@@ -53,4 +53,26 @@ module.exports = {
 }
 ```
 
+## Limitations
+
+Be aware that this plugin does not add a fallback for declarations with `var` statements
+when there is more than one declaration for a given CSS property in a single rule.
+
+For example, this plugin will not add a fallback for the `var` statement in this case:
+
+```css
+.example {
+   color: red;
+   color: var(--textColor, #333);
+}
+```
+
+The plugin assumes that the previous `color: red` declaration is a fallback. This prevents
+the plugin from having to parse the `var(--textColor, #333)` statement and compare the
+fallback there with any other `color:` declaration values. We found that such a check
+impacted performance enough that it was not worth the cost.
+
+To avoid incorrect or missing fallbacks, ensure that the CSS that you write does not have
+extraneous/duplicate declarations for the same CSS property.
+
 [official docs]: https://github.com/postcss/postcss#usage

--- a/index.js
+++ b/index.js
@@ -1,5 +1,47 @@
 'use strict';
 
+
+// Capture everything within var() https://regex101.com/r/7UYMv8/1
+const INSIDE_PAREN_REGEX = new RegExp(/var\(([^()]*\([^)]*\)|[^)]*)\)/);
+
+// Capture everything from first comma to end of string
+const CSS_VAR_FALLBACK_REGEX = new RegExp(/,(.*$)/);
+
+function shouldAddFallback(decl) {
+   // `str.includes` is 3-5% faster than using RegEx matching for this expression
+   if (!decl.value.includes('var(')) {
+      return false;
+   }
+
+   const siblings = decl.parent.nodes.filter((n) => { return n.prop === decl.prop; });
+
+   // If there is more than one CSS declaration for the same property, we assume that
+   // the other declaration is either a fallback for this declaration, or it overrides
+   // this declaration. In either case, we don't want to add a fallback.
+   //
+   // Of course, this assumption is not always true. We could have a style rule
+   // that contains multiple declarations for the same property, but the property appears
+   // first is not intended to be a fallback:
+   //
+   // .sloppy {
+   //    color: var(--defaultTextColor);
+   //    color: var(--overrideTextColor);
+   // }
+   //
+   // For the sake of simplicity and performance, we do not account for this case. In the
+   // above example, this plugin will not add any fallbacks.
+   return siblings.length === 1;
+}
+
+function getCSSVarFallbackValue(value) {
+   const cssVarParams = value.match(INSIDE_PAREN_REGEX),
+         rawFallbackValue = cssVarParams[1].match(CSS_VAR_FALLBACK_REGEX);
+
+   if (rawFallbackValue !== null) {
+      return rawFallbackValue[1].trim();
+   }
+}
+
 module.exports = () => {
 
    return {
@@ -7,58 +49,16 @@ module.exports = () => {
 
       Root(root) {
          root.walkDecls((decl) => {
+            if (!shouldAddFallback(decl)) {
+               return;
+            }
 
-            // Capture declarations with include var()
-            const cssVarRegEx = new RegExp(/var\(/);
+            const cssVarFallbackValue = getCSSVarFallbackValue(decl.value);
 
-            if (decl.value.match(cssVarRegEx)) {
+            if (cssVarFallbackValue) {
+               const cssFallbackRule = { prop: decl.prop, value: cssVarFallbackValue };
 
-               const cssPropertyValue = decl.prop;
-
-               let declarationRawLines,
-                   getCSSVarFallbackValue,
-                   cssVarFallbackValue;
-
-               declarationRawLines = decl
-                  .source
-                  .input
-                  .css
-                  .split('\n') // Splits on newlines to create a list of all the lines in the declaration.
-                  .map((line) => {
-                     // Strip out any spaces from the raw incoming statement.
-                     // We can use this for comparison when we build the fallback rule.
-                     return line.replace(/\s+/g, '');
-                  });
-
-               getCSSVarFallbackValue = (value) => {
-                  // Capture everything within var() https://regex101.com/r/7UYMv8/1
-                  const insideParenRegEx = new RegExp(/var\(([^()]*\([^)]*\)|[^)]*)\)/);
-
-                  // Capture everything from first comma to end of string
-                  const cssVarFallbackRegEx = new RegExp(/,(.*$)/);
-
-                  const cssVarParams = value.match(insideParenRegEx);
-
-                  const rawFallbackValue = cssVarParams[1].match(cssVarFallbackRegEx);
-
-                  if (rawFallbackValue !== null) {
-                     return rawFallbackValue[1].trim();
-                  }
-               };
-
-               cssVarFallbackValue = getCSSVarFallbackValue(decl.value);
-
-               if (cssVarFallbackValue) {
-                  const cssFallbackRule = { prop: cssPropertyValue, value: cssVarFallbackValue };
-
-                  // If a fallback value is already in the statement,
-                  // skip insertion of the fallback.
-                  if (declarationRawLines.indexOf(`${cssFallbackRule.prop}:${cssFallbackRule.value};`) > -1) {
-                     return;
-                  }
-
-                  decl.cloneBefore(cssFallbackRule);
-               }
+               decl.cloneBefore(cssFallbackRule);
             }
          });
       },

--- a/index.test.js
+++ b/index.test.js
@@ -48,6 +48,23 @@ it('Inserts hex fallback', async () => {
    await run(inputCSS, expectedOuput, {});
 });
 
+it('Inserts hex fallback with !important', async () => {
+   const inputCSS = `
+   a {
+      color: var(--color, #ffffff) !important;
+   }
+   `;
+
+   const expectedOuput = `
+   a {
+      color: #ffffff !important;
+      color: var(--color, #ffffff) !important;
+   }
+   `;
+
+   await run(inputCSS, expectedOuput, {});
+});
+
 it('Inserts complex hex fallback', async () => {
    const inputCSS = `
    a {
@@ -150,6 +167,23 @@ it('Inserts hsl fallback', async () => {
    await run(inputCSS, expectedOuput, {});
 });
 
+it('Inserts linear-gradient fallback', async () => {
+   const inputCSS = `
+      .test {
+         background-image: linear-gradient(to left, var(--color1, #4a6da7) 0%, var(--color2, #474747) 100%);
+      }
+   `;
+
+   const expectedOuput = `
+      .test {
+         background-image: linear-gradient(to left, #4a6da7 0%, #474747 100%);
+         background-image: linear-gradient(to left, var(--color1, #4a6da7) 0%, var(--color2, #474747) 100%);
+      }
+   `;
+
+   await run(inputCSS, expectedOuput, {});
+});
+
 it('Inserts no fallback', async () => {
    const inputCSS = `
       .test {
@@ -183,6 +217,39 @@ it('Skips when fallback already exists below the var line.', async () => {
       color: var(--color, #090);
       color: #090;
    }
+   `;
+
+   await run(inputCSS, inputCSS, {});
+});
+
+it('Skips existing hex color', async () => {
+   const inputCSS = `
+   a {
+      color: #4a6da7;
+      color: var(--color, #4a6da7);
+   }
+   `;
+
+   await run(inputCSS, inputCSS, {});
+});
+
+it('Skips existing rgba() fallback', async () => {
+   const inputCSS = `
+   a {
+      color: rgba(12, 12, 12, 0.5);
+      color: var(--color, rgba(12, 12, 12, 0.5));
+   }
+   `;
+
+   await run(inputCSS, inputCSS, {});
+});
+
+it('Skips existing hsla fallback', async () => {
+   const inputCSS = `
+      .test {
+         color: hsla(30, 100%, 50%, 0.6);
+         color: var(--color, hsla(30, 100%, 50%, 0.6));
+      }
    `;
 
    await run(inputCSS, inputCSS, {});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "css variables"
   ],
   "scripts": {
-    "test": "check-node-version --npm 6.14.12 && jest --coverage",
+    "test": "check-node-version --npm 6.14.12 && jest --coverage --coverageThreshold '{}'",
     "lint": "eslint .",
     "commitlint": "commitlint --from 62edc48",
     "markdownlint": "markdownlint \"README.md\"",


### PR DESCRIPTION
This PR includes the good work by @kmuncie in https://github.com/silvermine/postcss-css-var-fallback/pull/11

FWIW, I used a perf test library to make sure that the refactoring actually helped performance. Here's the results:

![image](https://user-images.githubusercontent.com/1326722/141491363-a1e4e108-1fe2-4237-8283-f37cdfe77895.png)

"Implementation 1" is the refactored version in this PR. "Implementation 2" is the current state of the main branch.

The improvements are not huge, but it may help some.